### PR TITLE
Add from impl for sqlx::Error to ApplicationError, remove map_err usages

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -93,6 +93,20 @@
       ]
     }
   },
+  "381a7815c3b74c4524421fa4b317e173a6ddb593b58d44c8091cab9e19b52c70": {
+    "query": "INSERT INTO form_input (id, form_id, type) \n                VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Text"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "3b8678240f9008db9ac2cd8370ae26042bf9ac2c90781ce3286542ba3d3db588": {
     "query": "INSERT INTO feedback (id, form_input_id, payload)\n             VALUES ($1, $2, $3)",
     "describe": {
@@ -109,20 +123,6 @@
   },
   "466444993736a84ff45386596e0dda73c98192642a3776bc3f1d7b90684a7763": {
     "query": "INSERT INTO form_input (id, form_id, type)\n             VALUES ($1, $2, $3)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Text"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "4da36462aa59d7780c6d6e189a1c2fa3ae0b6efce4cca2d261c2a70e4a06ec16": {
-    "query": "\n                    INSERT INTO form_input (id, form_id, type)\n                    VALUES ($1, $2, $3)\n                ",
     "describe": {
       "columns": [],
       "parameters": {

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 
 use crate::{auth::validate_request_with_basic_auth, db::NewUser};
 
-use super::{ApplicationError, ApplicationResponse};
+use super::ApplicationResponse;
 
 #[tracing::instrument(name = "handlers::login", skip(request, pool, id))]
 /// Get(/login) attempts to log a user in, and if successful stores the user in a session variable
@@ -14,8 +14,7 @@ pub async fn login(
     id: Identity,
 ) -> ApplicationResponse {
     let user = validate_request_with_basic_auth(request, &pool).await?;
-    let s = serde_json::to_string(&user)
-        .map_err(|e| ApplicationError::UnexpectedError(anyhow::anyhow!(e)))?;
+    let s = serde_json::to_string(&user)?;
     id.remember(s);
     Ok(HttpResponse::Ok().finish())
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -57,3 +57,15 @@ impl std::fmt::Debug for ApplicationError {
         crate::error::error_chain_fmt(self, f)
     }
 }
+
+impl From<sqlx::Error> for ApplicationError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::UnexpectedError(anyhow::anyhow!(e))
+    }
+}
+
+impl From<serde_json::Error> for ApplicationError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::UnexpectedError(anyhow::anyhow!(e))
+    }
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -72,8 +72,7 @@ fn run(listener: TcpListener, db_pool: PgPool) -> Result<Server, std::io::Error>
     let db_pool = Data::new(db_pool);
     let server = HttpServer::new(move || {
         let cors = Cors::default()
-            .allowed_origin_fn(|origin, _req_head| origin.as_bytes().ends_with(b"hermodapp.com"))
-            .allowed_origin("http://localhost:3000")
+            .allowed_origin_fn(|origin, _req_head| origin.as_bytes().ends_with(b"localhost:3000"))
             .allowed_methods(vec!["GET", "POST"])
             .supports_credentials()
             .max_age(3600);

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -72,7 +72,10 @@ fn run(listener: TcpListener, db_pool: PgPool) -> Result<Server, std::io::Error>
     let db_pool = Data::new(db_pool);
     let server = HttpServer::new(move || {
         let cors = Cors::default()
-            .allowed_origin_fn(|origin, _req_head| origin.as_bytes().ends_with(b"localhost:3000"))
+            .allowed_origin_fn(|origin, _req_head| {
+                origin.as_bytes().ends_with(b"hermodapp.com")
+                    || origin.as_bytes().ends_with(b"localhost:3000")
+            })
             .allowed_methods(vec!["GET", "POST"])
             .supports_credentials()
             .max_age(3600);


### PR DESCRIPTION
- Store form inputs as a transaction to reduce latency
- Add from impl for sqlx::Error to ApplicationError, remove map_err usages
